### PR TITLE
Build for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,17 +143,34 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: binary-linux-x64-gnu
-          path: rust-core/
+          path: ./downloaded-artifacts
 
-      - name: Verify downloaded files
+      - name: Verify and setup downloaded files
         run: |
           echo "=== Root directory structure ==="
           ls -la
-          echo "=== rust-core directory ==="
-          ls -la rust-core/ || echo "rust-core directory not found"
+          echo "=== Downloaded artifacts ==="
+          ls -la downloaded-artifacts/ || echo "downloaded-artifacts directory not found"
           echo "=== Looking for all .node files ==="
           find . -name "*.node" -type f
-          echo "=== Checking expected paths ==="
+          
+          # Ensure rust-core directory exists
+          mkdir -p rust-core
+          
+          # Copy files to expected location
+          if [ -f "downloaded-artifacts/index.node" ]; then
+            echo "✓ Found files in downloaded-artifacts/"
+            cp downloaded-artifacts/* rust-core/
+          elif [ -f "downloaded-artifacts/rust-core/index.node" ]; then
+            echo "✓ Found files in downloaded-artifacts/rust-core/"
+            cp downloaded-artifacts/rust-core/* rust-core/
+          else
+            echo "✗ Could not find artifacts in expected locations"
+            find downloaded-artifacts -name "*.node" -type f || echo "No .node files found"
+            exit 1
+          fi
+          
+          echo "=== Final verification ==="
           [ -f "rust-core/index.node" ] && echo "✓ rust-core/index.node exists" || echo "✗ rust-core/index.node missing"
           [ -f "rust-core/index.js" ] && echo "✓ rust-core/index.js exists" || echo "✗ rust-core/index.js missing"
           [ -f "rust-core/index.d.ts" ] && echo "✓ rust-core/index.d.ts exists" || echo "✗ rust-core/index.d.ts missing"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
           # Ensure rust-core directory exists
           mkdir -p rust-core
-          
+
           # Copy files to expected location and handle platform-specific naming
           if [ -f "downloaded-artifacts/index.js" ] && [ -f "downloaded-artifacts/index.d.ts" ]; then
             echo "✓ Found basic files in downloaded-artifacts/"
@@ -190,7 +190,9 @@ jobs:
             echo "✗ Could not find artifacts in expected locations"
             find downloaded-artifacts -name "*.node" -type f || echo "No .node files found"
             exit 1
-          fi          echo "=== Final verification ==="
+          fi
+
+          echo "=== Final verification ==="
           [ -f "rust-core/index.node" ] && echo "✓ rust-core/index.node exists" || echo "✗ rust-core/index.node missing"
           [ -f "rust-core/index.js" ] && echo "✓ rust-core/index.js exists" || echo "✗ rust-core/index.js missing"
           [ -f "rust-core/index.d.ts" ] && echo "✓ rust-core/index.d.ts exists" || echo "✗ rust-core/index.d.ts missing"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,10 @@ jobs:
           ls -la downloaded-artifacts/ || echo "downloaded-artifacts directory not found"
           echo "=== Looking for all .node files ==="
           find . -name "*.node" -type f
-          
+
           # Ensure rust-core directory exists
           mkdir -p rust-core
-          
+
           # Copy files to expected location
           if [ -f "downloaded-artifacts/index.node" ]; then
             echo "✓ Found files in downloaded-artifacts/"
@@ -169,7 +169,7 @@ jobs:
             find downloaded-artifacts -name "*.node" -type f || echo "No .node files found"
             exit 1
           fi
-          
+
           echo "=== Final verification ==="
           [ -f "rust-core/index.node" ] && echo "✓ rust-core/index.node exists" || echo "✗ rust-core/index.node missing"
           [ -f "rust-core/index.js" ] && echo "✓ rust-core/index.js exists" || echo "✗ rust-core/index.js missing"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,21 +156,41 @@ jobs:
 
           # Ensure rust-core directory exists
           mkdir -p rust-core
-
-          # Copy files to expected location
-          if [ -f "downloaded-artifacts/index.node" ]; then
-            echo "✓ Found files in downloaded-artifacts/"
-            cp downloaded-artifacts/* rust-core/
-          elif [ -f "downloaded-artifacts/rust-core/index.node" ]; then
+          
+          # Copy files to expected location and handle platform-specific naming
+          if [ -f "downloaded-artifacts/index.js" ] && [ -f "downloaded-artifacts/index.d.ts" ]; then
+            echo "✓ Found basic files in downloaded-artifacts/"
+            cp downloaded-artifacts/index.js rust-core/
+            cp downloaded-artifacts/index.d.ts rust-core/
+            
+            # Find and rename the platform-specific .node file
+            NODE_FILE=$(find downloaded-artifacts -name "*.node" -type f | head -1)
+            if [ -n "$NODE_FILE" ]; then
+              echo "✓ Found .node file: $NODE_FILE"
+              cp "$NODE_FILE" rust-core/index.node
+            else
+              echo "✗ No .node file found"
+              exit 1
+            fi
+          elif [ -f "downloaded-artifacts/rust-core/index.js" ]; then
             echo "✓ Found files in downloaded-artifacts/rust-core/"
-            cp downloaded-artifacts/rust-core/* rust-core/
+            cp downloaded-artifacts/rust-core/index.js rust-core/
+            cp downloaded-artifacts/rust-core/index.d.ts rust-core/
+            
+            # Find and rename the platform-specific .node file
+            NODE_FILE=$(find downloaded-artifacts/rust-core -name "*.node" -type f | head -1)
+            if [ -n "$NODE_FILE" ]; then
+              echo "✓ Found .node file: $NODE_FILE"
+              cp "$NODE_FILE" rust-core/index.node
+            else
+              echo "✗ No .node file found"
+              exit 1
+            fi
           else
             echo "✗ Could not find artifacts in expected locations"
             find downloaded-artifacts -name "*.node" -type f || echo "No .node files found"
             exit 1
-          fi
-
-          echo "=== Final verification ==="
+          fi          echo "=== Final verification ==="
           [ -f "rust-core/index.node" ] && echo "✓ rust-core/index.node exists" || echo "✗ rust-core/index.node missing"
           [ -f "rust-core/index.js" ] && echo "✓ rust-core/index.js exists" || echo "✗ rust-core/index.js missing"
           [ -f "rust-core/index.d.ts" ] && echo "✓ rust-core/index.d.ts exists" || echo "✗ rust-core/index.d.ts missing"


### PR DESCRIPTION
This pull request updates the CI workflow to improve how downloaded build artifacts are handled and verified. The main change is to make the artifact extraction process more robust by handling artifacts regardless of whether they are placed directly in the artifact root or within a subdirectory, and to ensure the expected files are always present in the correct location.

**CI Workflow Improvements:**

* Changed the artifact download path from `rust-core/` to `./downloaded-artifacts` to better control file placement and prevent conflicts.
* Enhanced the verification and setup step to:
  * Create the `rust-core` directory if it doesn't exist.
  * Copy `.node` files from either `downloaded-artifacts/` or `downloaded-artifacts/rust-core/` into `rust-core/`, handling both possible artifact structures.
  * Add clearer logging and error handling to help diagnose missing files or unexpected artifact layouts.
  * Perform a final check to confirm that `rust-core/index.node`, `rust-core/index.js`, and `rust-core/index.d.ts` exist after setup.