### PR TITLE
Build for windows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
           cat > package.json << EOF
           {
             "name": "solopdf-cli-${{ matrix.name }}",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "description": "SoloPDF CLI native binary for ${{ matrix.name }}",
             "main": "index.node",
             "files": ["index.node"],

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,15 @@
 name: Publish to NPM
 
+# Note: macOS support temporarily disabled due to NAPI linking issues
+# Working platforms: Windows x64, Linux x64
+
 on:
   release:
     types: [published]
   workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   build-binaries:
@@ -16,12 +22,13 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: linux-x64-gnu
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            name: darwin-x64
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            name: darwin-arm64
+          # TODO: macOS support - NAPI linking issues need to be resolved
+          # - target: x86_64-apple-darwin
+          #   os: macos-latest
+          #   name: darwin-x64
+          # - target: aarch64-apple-darwin
+          #   os: macos-latest
+          #   name: darwin-arm64
 
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.name }}
@@ -34,36 +41,65 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          target: ${{ matrix.target }}
           components: rustfmt, clippy
+          target: ${{ matrix.target }}
 
-      - name: Install additional Rust targets
+      - name: Verify Rust setup
         run: |
-          rustup target add ${{ matrix.target }}
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+          echo "=== Rust Setup Verification ==="
+          rustc --version
+          cargo --version
+          rustup show
+          echo "Installed targets:"
+          rustup target list --installed
+          echo "Default host: $(rustc -vV | grep host | cut -d' ' -f2)"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          # Use Node.js 20 for better NAPI compatibility
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Set macOS deployment target
-        if: matrix.os == 'macos-latest'
-        run: |
-          if [ "${{ matrix.target }}" = "aarch64-apple-darwin" ]; then
-            echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
-          else
-            echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
-          fi
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust-core/target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('rust-core/Cargo.lock') }}
 
-      - name: Build binary
+      - name: Validate Rust code (Linux only)
+        if: matrix.os == 'ubuntu-latest'
         working-directory: rust-core
         run: |
+          cargo fmt --check
+          cargo clippy --all-targets --all-features -- -D warnings
+          cargo test --verbose
+
+      - name: Build NAPI module
+        working-directory: rust-core
+        shell: bash
+        run: |
+          # Install dependencies first
           npm install
-          npx napi build --release --target ${{ matrix.target }}
+
+          # Build for the target
+          echo "Building for target: ${{ matrix.target }}"
+          echo "Runner OS: ${{ matrix.os }}"
+          echo "Runner architecture: $(uname -m)"
+          echo "Node architecture: $(node -p 'process.arch')"
+
+          # Build with explicit target for Windows and Linux
+          npx napi build --release --platform --target ${{ matrix.target }}
+
+      - name: Verify build output
+        working-directory: rust-core
+        shell: bash
+        run: |
+          echo "Checking build artifacts..."
+          ls -la *.node *.js *.d.ts 2>/dev/null || echo "No build artifacts found"
 
       - name: Create platform package
         run: |
@@ -82,12 +118,20 @@ jobs:
               "type": "git",
               "url": "https://github.com/soloflow-ai/solopdf-cli.git"
             },
-            "cpu": ["${{ matrix.name == 'darwin-arm64' && 'arm64' || 'x64' }}"],
-            "os": ["${{ matrix.name == 'win32-x64-msvc' && 'win32' || matrix.name == 'linux-x64-gnu' && 'linux' || 'darwin' }}"]
+            "cpu": ["${{ matrix.name == 'win32-x64-msvc' && 'x64' || 'x64' }}"],
+            "os": ["${{ matrix.name == 'win32-x64-msvc' && 'win32' || 'linux' }}"]
           }
           EOF
 
-          cp ../../rust-core/index.node .
+          # Find and copy the platform-specific .node file
+          NODE_FILE=$(find ../../rust-core -name "*.node" -type f | head -1)
+          if [ -n "$NODE_FILE" ]; then
+            echo "✓ Found .node file: $NODE_FILE"
+            cp "$NODE_FILE" index.node
+          else
+            echo "✗ No .node file found"
+            exit 1
+          fi
 
       - name: Publish platform package
         working-directory: platform-packages/solopdf-cli-${{ matrix.name }}
@@ -99,7 +143,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: binary-${{ matrix.name }}
-          path: rust-core/index.node
+          path: |
+            rust-core/*.node
+            rust-core/index.js
+            rust-core/index.d.ts
 
   publish-main:
     runs-on: ubuntu-latest
@@ -112,6 +159,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: "10.13.1"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -125,15 +174,51 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: binary-linux-x64-gnu
-          path: rust-core/
+          path: ./downloaded-artifacts
+
+      - name: Verify and setup downloaded files
+        run: |
+          echo "=== Downloaded artifacts ==="
+          ls -la downloaded-artifacts/ || echo "downloaded-artifacts directory not found"
+          echo "=== Looking for all .node files ==="
+          find . -name "*.node" -type f
+
+          # Ensure rust-core directory exists
+          mkdir -p rust-core
+
+          # Copy files to expected location and handle platform-specific naming
+          if [ -f "downloaded-artifacts/index.js" ] && [ -f "downloaded-artifacts/index.d.ts" ]; then
+            echo "✓ Found basic files in downloaded-artifacts/"
+            cp downloaded-artifacts/index.js rust-core/
+            cp downloaded-artifacts/index.d.ts rust-core/
+            
+            # Find and rename the platform-specific .node file
+            NODE_FILE=$(find downloaded-artifacts -name "*.node" -type f | head -1)
+            if [ -n "$NODE_FILE" ]; then
+              echo "✓ Found .node file: $NODE_FILE"
+              cp "$NODE_FILE" rust-core/index.node
+            else
+              echo "✗ No .node file found"
+              exit 1
+            fi
+          else
+            echo "✗ Could not find artifacts in expected locations"
+            find downloaded-artifacts -name "*.node" -type f || echo "No .node files found"
+            exit 1
+          fi
+          
+          echo "=== Final verification ==="
+          [ -f "rust-core/index.node" ] && echo "✓ rust-core/index.node exists" || echo "✗ rust-core/index.node missing"
+          [ -f "rust-core/index.js" ] && echo "✓ rust-core/index.js exists" || echo "✗ rust-core/index.js missing"
+          [ -f "rust-core/index.d.ts" ] && echo "✓ rust-core/index.d.ts exists" || echo "✗ rust-core/index.d.ts missing"
 
       - name: Install dependencies and build
         working-directory: node-wrapper
         run: |
-          pnpm install --frozen-lockfile
+          pnpm install --no-frozen-lockfile
           pnpm lint
           pnpm test
-          pnpm build
+          pnpm run build:ci
 
       - name: Publish main package
         working-directory: node-wrapper

--- a/node-wrapper/package-lock.json
+++ b/node-wrapper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solopdf-cli",
-  "version": "1.0.0",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solopdf-cli",
-      "version": "1.0.0",
+      "version": "0.0.4",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/node-wrapper/package.json
+++ b/node-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solopdf-cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A fast PDF manipulation CLI tool powered by Rust and Node.js",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solopdf-cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "SoloPDF CLI - A fast PDF manipulation tool with Rust core and Node.js wrapper",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing to NPM, primarily to address NAPI linking issues on macOS, improve build reliability, and update the package version to `0.0.4` across the project. The workflow now only builds for Windows and Linux, adds more robust artifact verification, and improves caching and validation steps. Several package files are also updated to reflect the new version.

**Build and Platform Support Updates:**

* Temporarily disables macOS builds due to unresolved NAPI linking issues, restricting supported platforms to Windows x64 and Linux x64. Comments and matrix entries for macOS are commented out for future re-enablement. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R3-R13) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L19-R31)
* Updates the workflow to use Node.js 20 (instead of 22) for better NAPI compatibility and adds caching for Rust dependencies to speed up builds.
* Adds validation steps to verify Rust setup, run formatting/linting/tests on Linux, and verify build output artifacts.

**Artifact Handling and Packaging Improvements:**

* Enhances artifact copying and verification, ensuring the correct `.node` file is found and copied, and that all required files (`index.node`, `index.js`, `index.d.ts`) are present before publishing. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L85-R134) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L128-R221)
* Updates the platform package creation to use version `0.0.4` and corrects the `cpu` and `os` fields for supported platforms. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L76-R112) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L85-R134)
* Changes the artifact upload step to include all relevant files (`*.node`, `index.js`, `index.d.ts`).

**Dependency and Build Process Tweaks:**

* Pins `pnpm` to version `10.13.1` and relaxes the install lockfile requirement to avoid build failures. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R162-R163) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L128-R221)
* Updates the build script in the main package to use `build:ci` for CI compatibility.

**Version Bump Across Packages:**

* Bumps the version to `0.0.4` in `package.json`, `node-wrapper/package.json`, and `node-wrapper/package-lock.json` to reflect the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-81b5251c1ba7a7470899c58683cc7ab2078a3b01e1e31bad5f54f367608257fcL3-R3) [[3]](diffhunk://#diff-735cdb76b3836bff598cae5eb5a3090f7e9cddaa5a39a93d3f9aad61c088bbeeL3-R9)